### PR TITLE
Update LLVMBuild.txt

### DIFF
--- a/lib/Target/Atomicc/LLVMBuild.txt
+++ b/lib/Target/Atomicc/LLVMBuild.txt
@@ -27,5 +27,5 @@ parent = Target
 type = Library
 name = AtomiccCodeGen
 parent = Atomicc
-required_libraries = AsmPrinter MC CodeGen Core AtomiccInfo SelectionDAG Support Target Interpreter ExecutionEngine RuntimeDyld Support
+required_libraries = AsmPrinter MC CodeGen Core AtomiccInfo SelectionDAG Support Target TransformUtils Interpreter ExecutionEngine RuntimeDyld Support
 add_to_library_groups = Atomicc


### PR DESCRIPTION
Lack one of lib, so I got build error both on Centos 6.9 and OSX 10.13.4 (with latest Xcode)